### PR TITLE
[ch75134]: Fix `BigDecimal.new()` warnings in empire projects

### DIFF
--- a/.github/workflows/gem_push_beta.yml
+++ b/.github/workflows/gem_push_beta.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   build:
     name: Test + Build + Publish
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       BUNDLER_ACCESS_TOKEN: ${{ secrets.TECH_OPS_ACCESS_TOKEN }}
 

--- a/.github/workflows/gem_push_master.yml
+++ b/.github/workflows/gem_push_master.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build + Publish
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/bureaucrat/fields/big_decimal_field.rb
+++ b/lib/bureaucrat/fields/big_decimal_field.rb
@@ -44,7 +44,7 @@ module Bureaucrat
 
         begin
           Utils.make_float(value)
-          BigDecimal.new(value)
+          BigDecimal(value)
         rescue ArgumentError
           raise ValidationError.new(error_messages[:invalid])
         end


### PR DESCRIPTION
## Ticket
  [Fix `BigDecimal.new()` warnings in empire projects](https://app.shortcut.com/sittercity/story/75134)
## Branch Link
  https://chch75134.staging.sittercity.com
## Related PRs
- https://github.com/sittercity/empire-monorepo/pull/62
## Clubhouse ticket notes:
  **Background:**

We're frequently seeing this message `Warning: BigDecimal.new is deprecated; use BigDecimal() method instead.` in the test output for empire projects. [example](https://github.com/sittercity/empire-monorepo/runs/3569627746?check_suite_focus=true#step:13:36)

The file below details all of the occurrences of `BigDecimal.new`. Replace the constructor syntax with `BigDecimal()`.
[big_decimal_occurences.txt](https://media.app.shortcut.com/api/attachments/files/clubhouse-assets/59484bf3-2d4b-4c00-abff-bded8af2a29a/61535ab1-134f-44aa-9b70-19619a65da90/big_decimal_occurences.txt)

**Acceptance criteria:**

- `BigDecimal.new()` has been replaced with `BigDecimal()` for all occurrences in the provided text file
