### PR TITLE
version bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,24 @@
 PATH
   remote: .
   specs:
-    bureaucrat-sc (2.1.0)
-      activesupport (= 5.2)
+    bureaucrat-sc (3.0.0)
+      activesupport (~> 6.0.4)
       i18n
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.0)
+    activesupport (6.0.4.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     concurrent-ruby (1.1.9)
     diff-lcs (1.3)
-    i18n (1.8.10)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     rake (12.0.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -35,6 +36,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby

--- a/bureaucrat-sc.gemspec
+++ b/bureaucrat-sc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.metadata    = { "github_repo" => "ssh://github.com/sittercity/bureaucrat" }
 
   s.add_runtime_dependency 'i18n'
-  s.add_runtime_dependency 'activesupport', '5.2'
+  s.add_runtime_dependency 'activesupport', '~> 6.0.4'
 
   s.add_development_dependency 'rake',  '12.0.0'
   s.add_development_dependency 'rspec', '3.6.0'

--- a/lib/bureaucrat/version.rb
+++ b/lib/bureaucrat/version.rb
@@ -1,3 +1,3 @@
 module Bureaucrat
-  VERSION = '2.1.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
version bump for the rails 6.0.x upgrade https://app.shortcut.com/sittercity/story/85007/upgrade-rails-to-6-0-4-7-for-empire-monorepo-applications-and-gems